### PR TITLE
feat: サイドバーとテーマ切り替えの改善 (Issue #17)

### DIFF
--- a/app/components/layout/Content.tsx
+++ b/app/components/layout/Content.tsx
@@ -1,0 +1,49 @@
+"use client";
+
+import { useEffect, useRef } from "react";
+import { motion, useInView } from "framer-motion";
+import { SectionId } from "./Portfolio";
+import HomeSection from "../sections/HomeSection";
+import AboutSection from "../sections/AboutSection";
+import SkillsSection from "../sections/SkillsSection";
+import ProjectsSection from "../sections/ProjectsSection";
+import ContactSection from "../sections/ContactSection";
+
+const sections: { id: SectionId; component: React.FC }[] = [
+  { id: "home", component: HomeSection },
+  { id: "about", component: AboutSection },
+  { id: "skills", component: SkillsSection },
+  { id: "projects", component: ProjectsSection },
+  { id: "contact", component: ContactSection },
+];
+
+interface ContentProps {
+  activeSection: SectionId;
+}
+
+export default function Content({ activeSection }: ContentProps) {
+  const containerRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    const sectionElement = document.getElementById(activeSection);
+    if (sectionElement && containerRef.current) {
+      containerRef.current.scrollTo({
+        top: sectionElement.offsetTop,
+        behavior: "smooth",
+      });
+    }
+  }, [activeSection]);
+
+  return (
+    <div
+      ref={containerRef}
+      className="h-screen overflow-y-scroll snap-y snap-mandatory"
+    >
+      {sections.map(({ id, component: Component }) => (
+        <section key={id} id={id} className="h-screen snap-center">
+          <Component />
+        </section>
+      ))}
+    </div>
+  );
+}

--- a/app/components/layout/Content.tsx
+++ b/app/components/layout/Content.tsx
@@ -5,14 +5,14 @@ import { motion, useInView } from "framer-motion";
 import { SectionId } from "./Portfolio";
 import HomeSection from "../sections/HomeSection";
 import AboutSection from "../sections/AboutSection";
-import SkillsSection from "../sections/SkillsSection";
+import ExperienceSection from "../sections/ExperienceSection";
 import ProjectsSection from "../sections/ProjectsSection";
 import ContactSection from "../sections/ContactSection";
 
 const sections: { id: SectionId; component: React.FC }[] = [
   { id: "home", component: HomeSection },
   { id: "about", component: AboutSection },
-  { id: "skills", component: SkillsSection },
+  { id: "experience", component: ExperienceSection },
   { id: "projects", component: ProjectsSection },
   { id: "contact", component: ContactSection },
 ];

--- a/app/components/layout/Content.tsx
+++ b/app/components/layout/Content.tsx
@@ -6,7 +6,7 @@ import { SectionId } from "./Portfolio";
 import HomeSection from "../sections/HomeSection";
 import AboutSection from "../sections/AboutSection";
 import ExperienceSection from "../sections/ExperienceSection";
-import ProjectsSection from "../sections/ProjectsSection";
+import { ProjectsSection } from "../sections/ProjectsSection";
 import ContactSection from "../sections/ContactSection";
 
 const sections: { id: SectionId; component: React.FC }[] = [

--- a/app/components/layout/Portfolio.tsx
+++ b/app/components/layout/Portfolio.tsx
@@ -1,88 +1,34 @@
 "use client";
 
-import { useState, useEffect } from "react";
-import Sidebar from "./Sidebar";
-import HomeSection from "../sections/HomeSection";
-import AboutSection from "../sections/AboutSection";
-import ExperienceSection from "../sections/ExperienceSection";
-import { ProjectsSection } from "../sections/ProjectsSection";
-import ContactSection from "../sections/ContactSection";
+import { useState } from "react";
+import Sidebar from "@/components/layout/Sidebar";
+import Content from "@/components/layout/Content";
+import Header from "@/components/layout/Header";
+import { ThemeToggle } from "@components/theme-toggle";
 
-export type SectionId =
-  | "home"
-  | "about"
-  | "experience"
-  | "projects"
-  | "contact";
+export type SectionId = "home" | "about" | "skills" | "projects" | "contact";
 
 export default function Portfolio() {
   const [activeSection, setActiveSection] = useState<SectionId>("home");
-  const [isLoaded, setIsLoaded] = useState(false);
 
-  useEffect(() => {
-    setIsLoaded(true);
-
-    // イベントリスナーを追加して、セクション変更イベントを処理
-    const handleSectionChange = (e: Event) => {
-      const { section } = (e as CustomEvent<{ section: SectionId }>).detail;
-      setActiveSection(section);
-    };
-
-    const portfolioElement = document.getElementById("portfolio");
-    portfolioElement?.addEventListener(
-      "changeSection",
-      handleSectionChange as EventListener
-    );
-
-    return () => {
-      portfolioElement?.removeEventListener(
-        "changeSection",
-        handleSectionChange as EventListener
-      );
-    };
-  }, []);
-
-  const renderContent = () => {
-    switch (activeSection) {
-      case "home":
-        return <HomeSection />;
-      case "about":
-        return <AboutSection />;
-      case "experience":
-        return <ExperienceSection />;
-      case "projects":
-        return <ProjectsSection />;
-      case "contact":
-        return <ContactSection />;
-      default:
-        return <HomeSection />;
-    }
+  const handleSectionChange = (section: SectionId) => {
+    setActiveSection(section);
   };
 
   return (
-    <div
-      id="portfolio"
-      className="min-h-screen flex bg-background text-foreground"
-    >
+    <div className="flex bg-background text-foreground">
       <Sidebar
         activeSection={activeSection}
         setActiveSection={setActiveSection}
       />
-
-      {/* Main Content */}
-      <main className="flex-1 relative overflow-y-auto">
-        <div
-          className={`h-full transition-all duration-700 ease-in-out transform ${
-            isLoaded ? "translate-x-0 opacity-100" : "translate-x-8 opacity-0"
-          }`}
-        >
-          {renderContent()}
-        </div>
-
+      <main className="relative flex-1 overflow-y-auto">
+        <ThemeToggle className="absolute right-6 top-6 z-50" />
+        <Header />
+        <Content activeSection={activeSection} />
         {/* Background Effects */}
-        <div className="absolute inset-0 pointer-events-none">
-          <div className="absolute top-1/4 right-1/4 w-64 h-64 bg-primary/10 rounded-full blur-3xl"></div>
-          <div className="absolute bottom-1/4 left-1/4 w-64 h-64 bg-primary/5 rounded-full blur-3xl"></div>
+        <div className="absolute inset-0 -z-10 pointer-events-none">
+          <div className="absolute top-1/4 right-1/4 w-72 h-72 bg-primary/10 rounded-full blur-3xl animate-pulse-slow"></div>
+          <div className="absolute bottom-1/4 left-1/4 w-72 h-72 bg-secondary/10 rounded-full blur-3xl animate-pulse-slow delay-2000"></div>
         </div>
       </main>
     </div>

--- a/app/components/layout/Portfolio.tsx
+++ b/app/components/layout/Portfolio.tsx
@@ -6,7 +6,12 @@ import Content from "@/components/layout/Content";
 import Header from "@/components/layout/Header";
 import { ThemeToggle } from "@components/theme-toggle";
 
-export type SectionId = "home" | "about" | "skills" | "projects" | "contact";
+export type SectionId =
+  | "home"
+  | "about"
+  | "experience"
+  | "projects"
+  | "contact";
 
 export default function Portfolio() {
   const [activeSection, setActiveSection] = useState<SectionId>("home");

--- a/app/components/layout/Portfolio.tsx
+++ b/app/components/layout/Portfolio.tsx
@@ -3,7 +3,6 @@
 import { useState } from "react";
 import Sidebar from "@/components/layout/Sidebar";
 import Content from "@/components/layout/Content";
-import Header from "@/components/layout/Header";
 import { ThemeToggle } from "@components/theme-toggle";
 
 export type SectionId =
@@ -28,7 +27,6 @@ export default function Portfolio() {
       />
       <main className="relative flex-1 overflow-y-auto">
         <ThemeToggle className="absolute right-6 top-6 z-50" />
-        <Header />
         <Content activeSection={activeSection} />
         {/* Background Effects */}
         <div className="absolute inset-0 -z-10 pointer-events-none">

--- a/app/components/layout/Portfolio.tsx
+++ b/app/components/layout/Portfolio.tsx
@@ -62,7 +62,7 @@ export default function Portfolio() {
   return (
     <div
       id="portfolio"
-      className="min-h-screen flex bg-background text-foreground overflow-hidden"
+      className="min-h-screen flex bg-background text-foreground"
     >
       <Sidebar
         activeSection={activeSection}
@@ -70,7 +70,7 @@ export default function Portfolio() {
       />
 
       {/* Main Content */}
-      <div className="flex-1 relative overflow-hidden">
+      <main className="flex-1 relative overflow-y-auto">
         <div
           className={`h-full transition-all duration-700 ease-in-out transform ${
             isLoaded ? "translate-x-0 opacity-100" : "translate-x-8 opacity-0"
@@ -84,7 +84,7 @@ export default function Portfolio() {
           <div className="absolute top-1/4 right-1/4 w-64 h-64 bg-primary/10 rounded-full blur-3xl"></div>
           <div className="absolute bottom-1/4 left-1/4 w-64 h-64 bg-primary/5 rounded-full blur-3xl"></div>
         </div>
-      </div>
+      </main>
     </div>
   );
 }

--- a/app/components/layout/Sidebar.tsx
+++ b/app/components/layout/Sidebar.tsx
@@ -21,7 +21,6 @@ import {
   TooltipProvider,
   TooltipTrigger,
 } from "@components/ui/tooltip";
-import { ThemeToggle } from "@components/theme-toggle";
 import { cn } from "@/lib/utils";
 import { Button } from "@components/ui/button";
 
@@ -85,7 +84,7 @@ export default function Sidebar({
   return (
     <div
       className={cn(
-        "relative flex h-full flex-col border-r bg-card transition-all duration-300 ease-in-out",
+        "relative flex h-screen flex-col border-r bg-card transition-all duration-300 ease-in-out",
         isCollapsed ? "w-20" : "w-64"
       )}
     >
@@ -104,23 +103,16 @@ export default function Sidebar({
       </div>
 
       <div className="mt-auto flex flex-col items-center gap-y-4 p-4">
-        {!isCollapsed && (
-          <div className="flex items-center justify-center gap-x-4">
-            {socialItems.map(({ name, icon: Icon, href }) => (
-              <a
-                key={name}
-                href={href}
-                target="_blank"
-                rel="noopener noreferrer"
-                className="text-muted-foreground transition-colors hover:text-foreground"
-              >
-                <Icon className="h-5 w-5" />
-                <span className="sr-only">{name}</span>
-              </a>
-            ))}
-          </div>
-        )}
-        <ThemeToggle />
+        <div
+          className={cn(
+            "flex items-center justify-center",
+            isCollapsed ? "flex-col gap-y-4" : "gap-x-4"
+          )}
+        >
+          {socialItems.map((item) => (
+            <SocialItem key={item.name} item={item} isCollapsed={isCollapsed} />
+          ))}
+        </div>
         <Button
           variant="ghost"
           size="icon"
@@ -168,5 +160,46 @@ function NavItem({ item, activeSection, onClick, isCollapsed }: NavItemProps) {
       <item.icon className="h-6 w-6" />
       <span>{item.label}</span>
     </Button>
+  );
+}
+
+function SocialItem({
+  item,
+  isCollapsed,
+}: {
+  item: SocialItem;
+  isCollapsed: boolean;
+}) {
+  if (isCollapsed) {
+    return (
+      <TooltipProvider>
+        <Tooltip delayDuration={0}>
+          <TooltipTrigger asChild>
+            <a
+              href={item.href}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="text-muted-foreground transition-colors hover:text-foreground"
+            >
+              <item.icon className="h-5 w-5" />
+              <span className="sr-only">{item.name}</span>
+            </a>
+          </TooltipTrigger>
+          <TooltipContent side="right">{item.name}</TooltipContent>
+        </Tooltip>
+      </TooltipProvider>
+    );
+  }
+
+  return (
+    <a
+      href={item.href}
+      target="_blank"
+      rel="noopener noreferrer"
+      className="text-muted-foreground transition-colors hover:text-foreground"
+    >
+      <item.icon className="h-5 w-5" />
+      <span className="sr-only">{item.name}</span>
+    </a>
   );
 }

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -33,7 +33,7 @@ export default function RootLayout({
       <body className="bg-background text-foreground min-h-screen">
         <ThemeProvider
           attribute="class"
-          defaultTheme="system"
+          defaultTheme="dark"
           enableSystem
           disableTransitionOnChange
         >

--- a/components/theme-toggle.tsx
+++ b/components/theme-toggle.tsx
@@ -5,8 +5,13 @@ import { Moon, Sun } from "lucide-react";
 import { useTheme } from "next-themes";
 
 import { Button } from "@components/ui/button";
+import { cn } from "../app/lib/utils";
 
-export function ThemeToggle() {
+interface ThemeToggleProps {
+  className?: string;
+}
+
+export function ThemeToggle({ className }: ThemeToggleProps) {
   const { theme, setTheme } = useTheme();
 
   return (
@@ -14,6 +19,7 @@ export function ThemeToggle() {
       variant="outline"
       size="icon"
       onClick={() => setTheme(theme === "dark" ? "light" : "dark")}
+      className={cn(className)}
     >
       <Sun className="h-[1.2rem] w-[1.2rem] rotate-0 scale-100 transition-all dark:-rotate-90 dark:scale-0" />
       <Moon className="absolute h-[1.2rem] w-[1.2rem] rotate-90 scale-0 transition-all dark:rotate-0 dark:scale-100" />

--- a/components/theme-toggle.tsx
+++ b/components/theme-toggle.tsx
@@ -5,36 +5,19 @@ import { Moon, Sun } from "lucide-react";
 import { useTheme } from "next-themes";
 
 import { Button } from "@components/ui/button";
-import {
-  DropdownMenu,
-  DropdownMenuContent,
-  DropdownMenuItem,
-  DropdownMenuTrigger,
-} from "@components/ui/dropdown-menu";
 
 export function ThemeToggle() {
-  const { setTheme } = useTheme();
+  const { theme, setTheme } = useTheme();
 
   return (
-    <DropdownMenu>
-      <DropdownMenuTrigger asChild>
-        <Button variant="outline" size="icon">
-          <Sun className="h-[1.2rem] w-[1.2rem] rotate-0 scale-100 transition-all dark:-rotate-90 dark:scale-0" />
-          <Moon className="absolute h-[1.2rem] w-[1.2rem] rotate-90 scale-0 transition-all dark:rotate-0 dark:scale-100" />
-          <span className="sr-only">Toggle theme</span>
-        </Button>
-      </DropdownMenuTrigger>
-      <DropdownMenuContent align="end">
-        <DropdownMenuItem onClick={() => setTheme("light")}>
-          Light
-        </DropdownMenuItem>
-        <DropdownMenuItem onClick={() => setTheme("dark")}>
-          Dark
-        </DropdownMenuItem>
-        <DropdownMenuItem onClick={() => setTheme("system")}>
-          System
-        </DropdownMenuItem>
-      </DropdownMenuContent>
-    </DropdownMenu>
+    <Button
+      variant="outline"
+      size="icon"
+      onClick={() => setTheme(theme === "dark" ? "light" : "dark")}
+    >
+      <Sun className="h-[1.2rem] w-[1.2rem] rotate-0 scale-100 transition-all dark:-rotate-90 dark:scale-0" />
+      <Moon className="absolute h-[1.2rem] w-[1.2rem] rotate-90 scale-0 transition-all dark:rotate-0 dark:scale-100" />
+      <span className="sr-only">Toggle theme</span>
+    </Button>
   );
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -38,6 +38,7 @@
         "clsx": "^2.0.0",
         "cmdk": "^1.1.1",
         "embla-carousel-react": "^8.6.0",
+        "framer-motion": "^12.18.1",
         "input-otp": "^1.4.2",
         "lucide-react": "^0.294.0",
         "next": "^13.4.19",
@@ -4584,6 +4585,32 @@
         "url": "https://github.com/sponsors/rawify"
       }
     },
+    "node_modules/framer-motion": {
+      "version": "12.18.1",
+      "resolved": "https://registry.npmjs.org/framer-motion/-/framer-motion-12.18.1.tgz",
+      "integrity": "sha512-6o4EDuRPLk4LSZ1kRnnEOurbQ86MklVk+Y1rFBUKiF+d2pCdvMjWVu0ZkyMVCTwl5UyTH2n/zJEJx+jvTYuxow==",
+      "dependencies": {
+        "motion-dom": "^12.18.1",
+        "motion-utils": "^12.18.1",
+        "tslib": "^2.4.0"
+      },
+      "peerDependencies": {
+        "@emotion/is-prop-valid": "*",
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@emotion/is-prop-valid": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "react-dom": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/fs.realpath": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
@@ -5778,6 +5805,19 @@
       "engines": {
         "node": ">=16 || 14 >=14.17"
       }
+    },
+    "node_modules/motion-dom": {
+      "version": "12.18.1",
+      "resolved": "https://registry.npmjs.org/motion-dom/-/motion-dom-12.18.1.tgz",
+      "integrity": "sha512-dR/4EYT23Snd+eUSLrde63Ws3oXQtJNw/krgautvTfwrN/2cHfCZMdu6CeTxVfRRWREW3Fy1f5vobRDiBb/q+w==",
+      "dependencies": {
+        "motion-utils": "^12.18.1"
+      }
+    },
+    "node_modules/motion-utils": {
+      "version": "12.18.1",
+      "resolved": "https://registry.npmjs.org/motion-utils/-/motion-utils-12.18.1.tgz",
+      "integrity": "sha512-az26YDU4WoDP0ueAkUtABLk2BIxe28d8NH1qWT8jPGhPyf44XTdDUh8pDk9OPphaSrR9McgpcJlgwSOIw/sfkA=="
     },
     "node_modules/ms": {
       "version": "2.1.3",
@@ -11170,6 +11210,16 @@
       "integrity": "sha512-ZsDfxO51wGAXREY55a7la9LScWpwv9RxIrYABrlvOFBlH/ShPnrtsXeuUIfXKKOVicNxQ+o8JTbJvjS4M89yew==",
       "dev": true
     },
+    "framer-motion": {
+      "version": "12.18.1",
+      "resolved": "https://registry.npmjs.org/framer-motion/-/framer-motion-12.18.1.tgz",
+      "integrity": "sha512-6o4EDuRPLk4LSZ1kRnnEOurbQ86MklVk+Y1rFBUKiF+d2pCdvMjWVu0ZkyMVCTwl5UyTH2n/zJEJx+jvTYuxow==",
+      "requires": {
+        "motion-dom": "^12.18.1",
+        "motion-utils": "^12.18.1",
+        "tslib": "^2.4.0"
+      }
+    },
     "fs.realpath": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
@@ -12002,6 +12052,19 @@
       "version": "7.1.2",
       "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.2.tgz",
       "integrity": "sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw=="
+    },
+    "motion-dom": {
+      "version": "12.18.1",
+      "resolved": "https://registry.npmjs.org/motion-dom/-/motion-dom-12.18.1.tgz",
+      "integrity": "sha512-dR/4EYT23Snd+eUSLrde63Ws3oXQtJNw/krgautvTfwrN/2cHfCZMdu6CeTxVfRRWREW3Fy1f5vobRDiBb/q+w==",
+      "requires": {
+        "motion-utils": "^12.18.1"
+      }
+    },
+    "motion-utils": {
+      "version": "12.18.1",
+      "resolved": "https://registry.npmjs.org/motion-utils/-/motion-utils-12.18.1.tgz",
+      "integrity": "sha512-az26YDU4WoDP0ueAkUtABLk2BIxe28d8NH1qWT8jPGhPyf44XTdDUh8pDk9OPphaSrR9McgpcJlgwSOIw/sfkA=="
     },
     "ms": {
       "version": "2.1.3",

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "clsx": "^2.0.0",
     "cmdk": "^1.1.1",
     "embla-carousel-react": "^8.6.0",
+    "framer-motion": "^12.18.1",
     "input-otp": "^1.4.2",
     "lucide-react": "^0.294.0",
     "next": "^13.4.19",


### PR DESCRIPTION
Closes #17

## 変更内容

- サイドバーを折りたたみ式にし、閉じた状態でもソーシャルアイコンが表示されるようにUIを改善しました。
- テーマ切り替え（ダークモード/ライトモード）ボタンをサイドバーからページ右上に移動しました。
- 上記変更に伴うリファクタリングの過程で発生した、複数のビルドエラーを修正しました。
  - `Header.tsx` が見つからない問題
  - `framer-motion` の依存関係の問題
  - `ProjectsSection` のインポート方法の誤り
  - `ThemeToggle` コンポーネントのプロパティとパスの不整合

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新機能**
  - セクションごとにスナップスクロール対応の新しいコンテンツ表示コンポーネントを追加しました。
  - サイドバーが折りたたみ可能になり、アイコンのみ／ラベル付きの表示を切り替えられるようになりました。

- **改善**
  - テーマ切り替えボタンを単純化し、ワンクリックでライト／ダークテーマを切り替え可能になりました。
  - サイドバーやレイアウトの構造を整理し、より直感的な操作性を実現しました。
  - デフォルトのテーマが「ダーク」になりました。

- **依存パッケージ**
  - アニメーション用ライブラリ「framer-motion」を追加しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->