### PR TITLE
フォントの変更対応

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -66,6 +66,22 @@
     overflow-x: hidden;
     font-feature-settings: "rlig" 1, "calt" 1;
   }
+
+  /* フォントファミリーの設定 */
+  :root {
+    --font-family-sans: var(--font-sans), sans-serif;
+    --font-family-mono: var(--font-jetbrains), var(--font-noto-mono), monospace;
+  }
+
+  /* 基本フォント設定 */
+  html {
+    font-family: var(--font-family-sans);
+  }
+
+  /* コード要素のフォント設定 */
+  code, pre, kbd, samp {
+    font-family: var(--font-family-mono);
+  }
 }
 
 @layer components {

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,12 +1,13 @@
 import { ThemeProvider } from "next-themes";
 import "./globals.css";
 import type { Metadata, Viewport } from "next";
-import { Inter as FontSans, JetBrains_Mono } from "next/font/google";
+import { Noto_Sans_JP as FontSans, JetBrains_Mono, Noto_Sans_Mono } from "next/font/google";
 import { cn } from "@/lib/utils";
 
 // フォント読み込みの最適化
 const fontSans = FontSans({
   subsets: ["latin"],
+  weight: ["400", "500", "700"],
   variable: "--font-sans",
   display: "swap", // テキストの早期表示のためにswapを使用
   preload: true,
@@ -14,14 +15,30 @@ const fontSans = FontSans({
   adjustFontFallback: true, // フォントフォールバックの自動調整
 });
 
-const fontMono = JetBrains_Mono({
+// 英語用モノスペースフォント
+const jetBrainsMono = JetBrains_Mono({
   subsets: ["latin"],
-  variable: "--font-mono",
+  variable: "--font-jetbrains",
   display: "swap",
   preload: true,
-  fallback: ["monospace"],
   adjustFontFallback: true,
 });
+
+// 日本語対応モノスペースフォント
+const notoSansMono = Noto_Sans_Mono({
+  subsets: ["latin"],
+  weight: ["400", "700"],
+  variable: "--font-noto-mono",
+  display: "swap",
+  preload: true,
+  adjustFontFallback: true,
+});
+
+// モノスペースフォント変数の統合
+const fontMono = {
+  variable: "--font-mono",
+  className: `${jetBrainsMono.variable} ${notoSansMono.variable}`,
+};
 
 // 環境変数またはデフォルト値からサイトURLを取得
 const siteUrl = process.env.NEXT_PUBLIC_SITE_URL || "https://micci184.dev";
@@ -103,7 +120,7 @@ export default function RootLayout({
         className={cn(
           "min-h-screen bg-background font-sans antialiased",
           fontSans.variable,
-          fontMono.variable
+          fontMono.className
         )}
       >
         <ThemeProvider


### PR DESCRIPTION
## 概要
Issue #56 の対応として、ポートフォリオサイトで使用するフォントを変更しました。

## 変更内容
1. サンセリフフォントを `Inter` から日本語対応の `Noto Sans JP` に変更
2. モノスペースフォントを `JetBrains Mono` と `Noto Sans Mono` の組み合わせに変更
3. フォントファミリー変数を適切に設定し、HTML要素に適用

## 期待される効果
- 日本語テキストの表示品質の向上
- コード表示の改善
- 全体的な可読性の向上

## 関連Issue
Closes #56